### PR TITLE
Import lock file rather than using `cargoHash`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,7 @@
           pname = "nixos-needsreboot";
           version = "0.1.10";
           src = ./.;
-
-          cargoHash = "sha256-LzO1kkrpWTjLnqs0HH5AIFLOZxtg0kUDIqXCVKSqsAc=";
+          cargoLock.lockFile = ./Cargo.lock;
         };
       });
     };


### PR DESCRIPTION
This fixes a hash mismatch in `0.1.10`, and removes the need to update the hash in `flake.nix` when the lock file changes in future releases.