### PR TITLE
Librarify

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,33 @@
+use std::error::Error;
+use std::fs;
+
+mod compare_nixos_modules;
+
+pub static OLD_SYSTEM_PATH: &str = "/run/booted-system";
+pub static NEW_SYSTEM_PATH: &str = "/nix/var/nix/profiles/system";
+
+#[derive(Debug)]
+pub enum NeedsReboot {
+    /// No reboot needed, running the latest NixOS generation
+    IsLatest,
+    /// No reboot needed, no updates available
+    NoUpdates,
+    /// Reboot needed, updates available
+    Updates(String),
+}
+
+pub fn needs_reboot() -> Result<NeedsReboot, Box<dyn Error>> {
+    let old_system_id = fs::read_to_string(OLD_SYSTEM_PATH.to_string() + "/nixos-version")?;
+    let new_system_id = fs::read_to_string(NEW_SYSTEM_PATH.to_string() + "/nixos-version")?;
+
+    Ok(if old_system_id == new_system_id {
+        NeedsReboot::IsLatest
+    } else {
+        let reason = compare_nixos_modules::upgrades_available()?;
+        if reason.is_empty() {
+            NeedsReboot::NoUpdates
+        } else {
+            NeedsReboot::Updates(reason)
+        }
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,8 @@ use std::error::Error;
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
+use nixos_needsreboot::NeedsReboot;
 
-mod compare_nixos_modules;
-
-pub static OLD_SYSTEM_PATH: &str = "/run/booted-system";
-pub static NEW_SYSTEM_PATH: &str = "/nix/var/nix/profiles/system";
 pub static NIXOS_NEEDS_REBOOT: &str = "/var/run/reboot-required";
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -30,28 +27,24 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     if Path::new("/nix/var/nix/profiles/system").exists() {
-        let old_system_id = fs::read_to_string(OLD_SYSTEM_PATH.to_string() + "/nixos-version")?;
-        let new_system_id = fs::read_to_string(NEW_SYSTEM_PATH.to_string() + "/nixos-version")?;
-
         if Path::new(NIXOS_NEEDS_REBOOT).exists() {
             let stdout = io::stdout();
             let mut handle = stdout.lock();
             let _ = handle.write_all(&fs::read(NIXOS_NEEDS_REBOOT)?);
             let _ = handle.flush();
             std::process::exit(2);
-        } else if old_system_id == new_system_id {
-            eprintln!("DEBUG: you are using the latest NixOS generation, no need to reboot");
         } else {
-            let reason = compare_nixos_modules::upgrades_available()?;
-            if reason.is_empty() {
-                eprintln!("DEBUG: no updates available, moar uptime!!!");
-            } else {
-                if dry_run {
-                    println!("{reason}");
-                } else {
-                    fs::write(NIXOS_NEEDS_REBOOT, reason)?;
+            match nixos_needsreboot::needs_reboot()? {
+                NeedsReboot::IsLatest => eprintln!("DEBUG: you are using the latest NixOS generation, no need to reboot"),
+                NeedsReboot::NoUpdates => eprintln!("DEBUG: no updates available, moar uptime!!!"),
+                NeedsReboot::Updates(reason) => {
+                    if dry_run {
+                        println!("{reason}");
+                    } else {
+                        fs::write(NIXOS_NEEDS_REBOOT, reason)?;
+                    }
+                    std::process::exit(2);
                 }
-                std::process::exit(2);
             }
         }
     } else {


### PR DESCRIPTION
Adds a `lib.rs` to allow using this as a Rust library directly without having to spawn a subprocess.